### PR TITLE
Consume spwn 0.35.1 - our first stable open-source package provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.17.0 (2024-04-20)
+
+
+### 🚀 Features
+
+- **generator:** upgrade to @spwntch/...@0.35.1 ([b529543](https://github.com/spwntch/spwn-workspace-generator/commit/b529543))
+
+### ❤️  Thank You
+
+- zpydee @zpydee
+
 ## 0.15.4 (2024-04-18)
 
 

--- a/packages/spawn-workspace/package.json
+++ b/packages/spawn-workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spawn-workspace",
-  "version": "0.15.4",
+  "version": "0.17.0",
   "type": "commonjs",
   "files": [
     "dist/bin"

--- a/packages/workspace-generator/package.json
+++ b/packages/workspace-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spwntch/workspace-generator",
-  "version": "0.15.4",
+  "version": "0.17.0",
   "dependencies": {
     "@nx/devkit": "18.2.4",
     "tslib": "^2.3.0"

--- a/packages/workspace-generator/src/generators/preset/generator.ts
+++ b/packages/workspace-generator/src/generators/preset/generator.ts
@@ -28,9 +28,9 @@ export async function presetGenerator(
   addDependenciesToPackageJson(
     tree,
     {
-      '@spwntch/shell': '0.34.0',
-      '@spwntch/components': '0.34.0',
-      '@spwntch/tailwind': '0.34.0',
+      '@spwntch/shell': '0.35.1',
+      '@spwntch/components': '0.35.1',
+      '@spwntch/tailwind': '0.35.1',
       next: '14.0.4',
       react: '18.2.0',
       'react-dom': '18.2.0',


### PR DESCRIPTION
## Why are you awakening us?

> This is a stake in the sand. We recognise now that `@spwntch/spwn` is our package provider and that this licesne represents the consumer. Embracing this architecture will help us better achieve our goals.Ï

## What did you change?

> Just using `@spwntch/spwn@0.35.1`. This is our new version of truth.

## Any risks?

> Don't think so.

## Future Opportunities?

> Onward and upward.Ï
